### PR TITLE
bug fixes

### DIFF
--- a/pkg/service/api.go
+++ b/pkg/service/api.go
@@ -69,6 +69,7 @@ func (s *ApiServer) UseMiddleware(middlware echo.MiddlewareFunc) {
 
 func (s *ApiServer) SetCustomExtender(extender api.ApiContextExtender) {
 	s.extender = extender
+	s.server.Use(s.extender.ExtendDefaultApiContext)
 }
 
 func (s *ApiServer) registerExtender() {

--- a/pkg/service/configuration/postgres.go
+++ b/pkg/service/configuration/postgres.go
@@ -30,12 +30,12 @@ func (c *ServiceConfiguration) loadPostgresStorageConfig(name string) (cfg *Post
 
 	name = strings.ToUpper(name)
 
-	cfg.Hostname = env.Get(fmt.Sprintf("NS_DB_PG_%s_HOSTNAME", cfg.Hostname))
+	cfg.Hostname = env.Get(fmt.Sprintf("NS_DB_PG_%s_HOSTNAME", name), cfg.Hostname)
 	cfg.Port = env.GetInt(fmt.Sprintf("NS_DB_PG_%s_PORT", name), cfg.Port)
-	cfg.SSLMode = env.Get(fmt.Sprintf("NS_DB_PG_%s_SSLMODE", cfg.SSLMode))
-	cfg.Username = env.Get(fmt.Sprintf("NS_DB_PG_%s_USERNAME", cfg.Username))
-	cfg.Password = env.Get(fmt.Sprintf("NS_DB_PG_%s_PASSWORD", cfg.Password))
-	cfg.Database = env.Get(fmt.Sprintf("NS_DB_PG_%s_DATABASE", cfg.Database))
+	cfg.SSLMode = env.Get(fmt.Sprintf("NS_DB_PG_%s_SSLMODE", name), cfg.SSLMode)
+	cfg.Username = env.Get(fmt.Sprintf("NS_DB_PG_%s_USERNAME", name), cfg.Username)
+	cfg.Password = env.Get(fmt.Sprintf("NS_DB_PG_%s_PASSWORD", name), cfg.Password)
+	cfg.Database = env.Get(fmt.Sprintf("NS_DB_PG_%s_DATABASE", name), cfg.Database)
 
 	if cfg.Database == "" || cfg.Hostname == "" || cfg.Username == "" {
 		return nil, errors.Critical.Newf("invalid env parameters for database '%s': %s", name, spew.Sdump(cfg))


### PR DESCRIPTION
1. Fix setting up custom contest extender
As I got from [here](https://echo.labstack.com/guide/context/) you need set up extending context as middleware. So It's not enough just switch extender in sever struct, in this case server still uses default context extender and you wouldn't be able to extect context as your custom context outside framework 

2. Fix default postgres config values loading
Default values from config were used as service name.